### PR TITLE
bump bundler requirement to latest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    optimizely (1.2.1)
+    optimizely (1.2.2)
       json (~> 1.8.3)
 
 GEM
@@ -24,11 +24,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.10.6)
+  bundler (~> 1.13.6)
   optimizely!
   pry (~> 0.10.1)
   rake (~> 10.4.2)
   test-unit (~> 3.1.2)
 
 BUNDLED WITH
-   1.10.6
+   1.13.6

--- a/optimizely.gemspec
+++ b/optimizely.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'json', '~> 1.8.3'
 
-  s.add_development_dependency 'bundler', '~> 1.10.6'
+  s.add_development_dependency 'bundler', '~> 1.13.6'
   s.add_development_dependency 'rake', '~> 10.4.2'
   s.add_development_dependency 'test-unit', '~> 3.1.2'
   s.add_development_dependency 'pry', '~> 0.10.1'


### PR DESCRIPTION
Tests pass before/after the change.

Since this is only a development dependency, I don't see the reason why we shouldn't bump this so that developers don't have to keep typing `bundle _1.10.6_ <command>`