### PR TITLE
relax json boundaries to allow 2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,13 @@ PATH
   remote: .
   specs:
     optimizely (1.2.2)
-      json (~> 1.8.3)
+      json (>= 1.8.3)
 
 GEM
   remote: http://www.rubygems.org/
   specs:
     coderay (1.1.0)
-    json (1.8.3)
+    json (2.0.2)
     method_source (0.8.2)
     power_assert (0.2.4)
     pry (0.10.1)

--- a/optimizely.gemspec
+++ b/optimizely.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths    = ["lib"]
   s.extra_rdoc_files = ["README.md"]
 
-  s.add_runtime_dependency 'json', '~> 1.8.3'
+  s.add_runtime_dependency 'json', '>= 1.8.3'
 
   s.add_development_dependency 'bundler', '~> 1.13.6'
   s.add_development_dependency 'rake', '~> 10.4.2'


### PR DESCRIPTION
The tests pass before/after this change.

The biggest change in JSON 2.0 was that it now complies to JSON RFC 7159.
https://github.com/flori/json/blob/master/CHANGES.md#2015-09-11-200

fixes https://github.com/MartijnSch/optimizely-gem/issues/3